### PR TITLE
Add jsconfig to allow decorators

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+      "experimentalDecorators": true
+  }
+}


### PR DESCRIPTION
Stops annoying eslint warnings when using decorators.
<img width="543" alt="Screen Shot 2020-03-05 at 10 47 24 AM" src="https://user-images.githubusercontent.com/39747557/76014597-bfa8b500-5ece-11ea-93af-40aa0fedae76.png">
